### PR TITLE
closes #12 This adds a function to get account summaries for both user and admin accounts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
               --network=host \
               -e API_SERVER_PORT=3033 \
               -e CBS_SERVER_ADDRESS=http://localhost:4001 \
-              -d adharaprojects/cbs-proxy:0.0.2
+              -d adharaprojects/cbs-proxy:0.0.3
 
       - run:
           name: Wait for cyclos to be ready

--- a/README.md
+++ b/README.md
@@ -28,6 +28,6 @@ const cbsProxyClient = require('cbs-proxy-client')
 const proxyClient = await cbsProxyClient('admin', 'abcd', 'http://localhost:4000')
 
 // get all transfers after a certain timestamp
-const omnibusToTransfersSinceTimestamp = await proxyClient.getTransfersToOmnibusAccount(1533077567.294)
-const omnibusFromTransfersSinceTimestamp = await proxyClient.getTransfersFromOmnibusAccount(1533077567.294)
+const primaryAccountToTransfersSinceTimestamp = await proxyClient.getTransfersToPrimaryAccount(1533077567.294)
+const primaryAccountFromTransfersSinceTimestamp = await proxyClient.getTransfersFromPrimaryAccount(1533077567.294)
 ```

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,8 +17,8 @@ const getAuthOptions = (username, password) => ({
     password
   })
 })
-const getOmnibusAccountIdUri = baseUrl => baseUrl + '/cbs/getOmnibusAccountId'
-const getOmnibusAccountIdOption = sessionToken => ({
+const getPrimaryAccountIdUri = baseUrl => baseUrl + '/cbs/getPrimaryAccountId'
+const getPrimaryAccountIdOption = sessionToken => ({
   ...fetchOptionsTemplate,
   body: JSON.stringify({
     sessionToken
@@ -54,18 +54,18 @@ const createTokenProxy = async (username, password, url) => {
     )
   ).sessionToken
 
-  const omnibusAccountId = (
+  const primaryAccountId = (
     await fetchJson(
-      getOmnibusAccountIdUri(url),
-      getOmnibusAccountIdOption(sessionToken)
+      getPrimaryAccountIdUri(url),
+      getPrimaryAccountIdOption(sessionToken)
     )
-  ).omnibusAccountId
+  ).primaryAccountId
 
   const getTransfersToOmnibusAccount = async (fromTime) => {
     const transfers = (
       await fetchJson(
         transfersUri(url),
-        transfersOption(sessionToken, omnibusAccountId, {datePeriod: {fromTime}, direction: 'credit'})
+        transfersOption(sessionToken, primaryAccountId, {datePeriod: {fromTime}, direction: 'credit'})
       )
     )
     return transfers
@@ -74,7 +74,7 @@ const createTokenProxy = async (username, password, url) => {
     const transfers = (
       await fetchJson(
         transfersUri(url),
-        transfersOption(sessionToken, omnibusAccountId, {datePeriod: {fromTime}, direction: 'debit'})
+        transfersOption(sessionToken, primaryAccountId, {datePeriod: {fromTime}, direction: 'debit'})
       )
     )
     return transfers
@@ -102,7 +102,7 @@ const createTokenProxy = async (username, password, url) => {
     const transferResult = (
       await fetchJson(
         getAccountDetailsUri(url),
-        getAccountDetailsOption({sessionToken, accountId: omnibusAccountId})
+        getAccountDetailsOption({sessionToken, accountId: primaryAccountId})
       )
     )
     return transferResult

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,8 +33,8 @@ const transfersOption = (sessionToken, accountId, queryParameters) => ({
     queryParameters
   })
 })
-const makeTransferToOmnibusAccountUri = baseUrl => baseUrl + '/cbs/transferToOmnibus'
-const makeTransferFromOmnibusAccountUri = baseUrl => baseUrl + '/cbs/transferFromOmnibus'
+const makeTransferToPrimaryAccountUri = baseUrl => baseUrl + '/cbs/transferToAdminPrimaryAccount'
+const makeTransferFromPrimaryAccountUri = baseUrl => baseUrl + '/cbs/transferFromAdminPrimaryAccount'
 const makeTransferOption = (queryParameters) => ({
   ...fetchOptionsTemplate,
   body: JSON.stringify(queryParameters)
@@ -61,7 +61,7 @@ const createTokenProxy = async (username, password, url) => {
     )
   ).primaryAccountId
 
-  const getTransfersToOmnibusAccount = async (fromTime) => {
+  const getTransfersToPrimaryAccount = async (fromTime) => {
     const transfers = (
       await fetchJson(
         transfersUri(url),
@@ -70,7 +70,7 @@ const createTokenProxy = async (username, password, url) => {
     )
     return transfers
   }
-  const getTransfersFromOmnibusAccount = async (fromTime) => {
+  const getTransfersFromPrimaryAccount = async (fromTime) => {
     const transfers = (
       await fetchJson(
         transfersUri(url),
@@ -79,19 +79,19 @@ const createTokenProxy = async (username, password, url) => {
     )
     return transfers
   }
-  const makeTransferToOmnibusAccount = async (amount, message) => {
+  const makeTransferToAdminPrimaryAccount = async (amount, message) => {
     const transferResult = (
       await fetchJson(
-        makeTransferToOmnibusAccountUri(url),
+        makeTransferToPrimaryAccountUri(url),
         makeTransferOption({sessionToken, amount, message})
       )
     )
     return transferResult
   }
-  const makeTransferFromOmnibusAccount = async (amount, message, accountId) => {
+  const makeTransferFromAdminPrimaryAccount = async (amount, message, accountId) => {
     const transferResult = (
       await fetchJson(
-        makeTransferFromOmnibusAccountUri(url),
+        makeTransferFromPrimaryAccountUri(url),
         makeTransferOption({sessionToken, amount, message, accountId})
       )
     )
@@ -109,10 +109,10 @@ const createTokenProxy = async (username, password, url) => {
   }
 
   return {
-    getTransfersToOmnibusAccount,
-    getTransfersFromOmnibusAccount,
-    makeTransferToOmnibusAccount,
-    makeTransferFromOmnibusAccount,
+    getTransfersToPrimaryAccount,
+    getTransfersFromPrimaryAccount,
+    makeTransferToAdminPrimaryAccount,
+    makeTransferFromAdminPrimaryAccount,
     getAccountDetails
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -112,7 +112,11 @@ const createTokenProxy = async (username, password, url) => {
     getTransfersToPrimaryAccount,
     getTransfersFromPrimaryAccount,
     makeTransferToAdminPrimaryAccount,
-    makeTransferFromAdminPrimaryAccount,
+    makeTransferFromAdminPrimaryAccount
+    getTransfersToOmnibusAccount: getTransfersToPrimaryAccount,
+    getTransfersFromOmnibusAccount: getTransfersFromPrimaryAccount,
+    makeTransferToOmnibusAccount: makeTransferToAdminPrimaryAccount,
+    makeTransferFromOmnibusAccount: makeTransferFromAdminPrimaryAccount,
     getAccountDetails
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -112,7 +112,7 @@ const createTokenProxy = async (username, password, url) => {
     getTransfersToPrimaryAccount,
     getTransfersFromPrimaryAccount,
     makeTransferToAdminPrimaryAccount,
-    makeTransferFromAdminPrimaryAccount
+    makeTransferFromAdminPrimaryAccount,
     getTransfersToOmnibusAccount: getTransfersToPrimaryAccount,
     getTransfersFromOmnibusAccount: getTransfersFromPrimaryAccount,
     makeTransferToOmnibusAccount: makeTransferToAdminPrimaryAccount,

--- a/lib/index.js
+++ b/lib/index.js
@@ -39,6 +39,11 @@ const makeTransferOption = (queryParameters) => ({
   ...fetchOptionsTemplate,
   body: JSON.stringify(queryParameters)
 })
+const getAccountDetailsUri = baseUrl => baseUrl + '/cbs/accountSummary'
+const getAccountDetailsOption = (queryParameters) => ({
+  ...fetchOptionsTemplate,
+  body: JSON.stringify(queryParameters)
+})
 
 // NOTE: I chose to use a functor like constructor with closures rather than classes because I don't like needing to call `new`
 const createTokenProxy = async (username, password, url) => {
@@ -92,12 +97,23 @@ const createTokenProxy = async (username, password, url) => {
     )
     return transferResult
   }
+  // TODO:: could add time based filtering in the future
+  const getAccountDetails = async () => {
+    const transferResult = (
+      await fetchJson(
+        getAccountDetailsUri(url),
+        getAccountDetailsOption({sessionToken, accountId: omnibusAccountId})
+      )
+    )
+    return transferResult
+  }
 
   return {
     getTransfersToOmnibusAccount,
     getTransfersFromOmnibusAccount,
     makeTransferToOmnibusAccount,
-    makeTransferFromOmnibusAccount
+    makeTransferFromOmnibusAccount,
+    getAccountDetails
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cbs-proxy-client",
-  "version": "0.0.5",
+  "version": "0.0.5-transition",
   "description": "Client that creates functions for the cbs-proxy.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cbs-proxy-client",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Client that creates functions for the cbs-proxy.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cbs-proxy-client",
-  "version": "0.0.5-transition",
+  "version": "0.0.5-transition-2",
   "description": "Client that creates functions for the cbs-proxy.",
   "main": "lib/index.js",
   "scripts": {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -17,8 +17,8 @@ const getAuthOptions = (username, password) => ({
     password
   })
 })
-const makeTransferToOmnibusUri = config.cyclosUrl +  '/api/self/payments?fields=id&fields=authorizationStatus'
-const makeTransferToOmnibusOption = (sessionToken, transferDataBody) => ({
+const makeTransferToPrimaryAccountUri = config.cyclosUrl +  '/api/self/payments?fields=id&fields=authorizationStatus'
+const makeTransferToPrimaryAccountOption = (sessionToken, transferDataBody) => ({
   ...fetchOptionsTemplate,
   headers: {
     ...fetchOptionsTemplate.headers,
@@ -32,26 +32,26 @@ function sleep(ms) {
 }
 
 // TODO: make these transfers random in value
-const makeRandomTransfersToOmnibusAccount = async (numberOfTransfers, sessionToken) => {
+const makeRandomTransfersToAdminPrimaryAccount = async (numberOfTransfers, sessionToken) => {
   let transferArray = []
   let timestamp
   for(let i = 0; i < numberOfTransfers; ++i) {
     timestamp = new Date() / 1000
     const transferDetails = {amount:'1.0' + i, description:"randomTest #"+i, type:"user.toOrganization", subject:"system"}
-    let txId = await fetchJson(makeTransferToOmnibusUri ,makeTransferToOmnibusOption(sessionToken, transferDetails))
+    let txId = await fetchJson(makeTransferToPrimaryAccountUri, makeTransferToPrimaryAccountOption(sessionToken, transferDetails))
     transferArray = [...transferArray, {timestamp, txId, transferDetails}]
   }
   await sleep(2000)
   return transferArray
 }
 // TODO: make these transfers random in value
-const makeRandomTransfersFromOmnibusAccount = async (numberOfTransfers, sessionToken) => {
+const makeRandomTransfersFromAdminPrimaryAccount = async (numberOfTransfers, sessionToken) => {
   let transferArray = []
   let timestamp
   for(let i = 0; i < numberOfTransfers; ++i) {
     timestamp = new Date() / 1000
     const transferDetails = {amount:'1.0' + i, description:"randomTest #"+i, type:"organization.toUser", subject: config.cbsAccountUser1}
-    let txId = await fetchJson(makeTransferToOmnibusUri ,makeTransferToOmnibusOption(sessionToken, transferDetails))
+    let txId = await fetchJson(makeTransferToPrimaryAccountUri ,makeTransferToPrimaryAccountOption(sessionToken, transferDetails))
     transferArray = [...transferArray, {timestamp, txId, transferDetails}]
   }
   await sleep(2000)
@@ -69,7 +69,7 @@ const getSessionToken = async (username, password, url) => {
 
 module.exports= {
   getSessionToken,
-  makeRandomTransfersFromOmnibusAccount,
-  makeRandomTransfersToOmnibusAccount,
+  makeRandomTransfersFromAdminPrimaryAccount,
+  makeRandomTransfersToAdminPrimaryAccount,
   sleep
 }

--- a/test/index.js
+++ b/test/index.js
@@ -4,8 +4,8 @@ const {
 } = require('chai')
 const cbsProxyClient = require('../lib')
 const {
-  makeRandomTransfersToOmnibusAccount,
-  makeRandomTransfersFromOmnibusAccount,
+  makeRandomTransfersToAdminPrimaryAccount,
+  makeRandomTransfersFromAdminPrimaryAccount,
   getSessionToken,
   sleep
 } = require('./helpers.js')
@@ -22,80 +22,80 @@ describe("The core banking system proxy", function() {
   })
 
 
-  describe('getTransfersToOmnibusAccount', () => {
+  describe('getTransfersToPrimaryAccount', () => {
     let transfers
 
     before (async () => {
       const sessionToken = await getSessionToken(config.cbsUnameUser1, config.cbsPasswordUser1, config.cbsProxyUrl)
-      transfers = await makeRandomTransfersToOmnibusAccount(11, sessionToken)
+      transfers = await makeRandomTransfersToAdminPrimaryAccount(11, sessionToken)
     })
-    it("returns a list of TO transfers of the omnibus account after a certain date", async () => {
+    it("returns a list of TO transfers of the adminPrimary account after a certain date", async () => {
       for (let i = 0; i < transfers.length; ++i) {
-        const omnibusCreditsFromTimestamp = await adminProxyClient.getTransfersToOmnibusAccount(transfers[i].timestamp)
-        console.log(omnibusCreditsFromTimestamp.transfers.length, 'transfers occured since', Date(transfers[i].timestamp * 1000))
-        expect(omnibusCreditsFromTimestamp.transfers.length).to.be.equal(transfers.length - i)
+        const adminPrimaryCreditsSinceTimestamp = await adminProxyClient.getTransfersToPrimaryAccount(transfers[i].timestamp)
+        console.log(adminPrimaryCreditsSinceTimestamp.transfers.length, 'transfers occured since', Date(transfers[i].timestamp * 1000))
+        expect(adminPrimaryCreditsSinceTimestamp.transfers.length).to.be.equal(transfers.length - i)
       }
     })
     it("returns a list of FROM transfers of user account after a certain date", async () => {
       for (let i = 0; i < transfers.length; ++i) {
-        const userDebitTrnsferFromTimestamp = await adminProxyClient.getTransfersToOmnibusAccount(transfers[i].timestamp)
-        console.log(userDebitTrnsferFromTimestamp.transfers.length, 'transfers occured since', Date(transfers[i].timestamp * 1000))
-        expect(userDebitTrnsferFromTimestamp.transfers.length).to.be.equal(transfers.length - i)
+        const userDebitTrnsferSinceTimestamp = await adminProxyClient.getTransfersToPrimaryAccount(transfers[i].timestamp)
+        console.log(userDebitTrnsferSinceTimestamp.transfers.length, 'transfers occured since', Date(transfers[i].timestamp * 1000))
+        expect(userDebitTrnsferSinceTimestamp.transfers.length).to.be.equal(transfers.length - i)
       }
     })
   })
 
-  describe('getTransfersFromOmnibusAccount', () => {
+  describe('getTransfersFromPrimaryAccount', () => {
     let transfers
     let user
 
     before (async () => {
       const sessionToken = await getSessionToken(config.cbsUnameAdmin, config.cbsPasswordAdmin, config.cbsProxyUrl)
-      transfers = await makeRandomTransfersFromOmnibusAccount(11, sessionToken)
+      transfers = await makeRandomTransfersFromAdminPrimaryAccount(11, sessionToken)
     })
-    it("returns a list of FROM transfers to the omnibus account after a certain date", async () => {
+    it("returns a list of FROM transfers to the adminPrimary account after a certain date", async () => {
       for (let i = 0; i < transfers.length; ++i) {
-        const omnibusCreditsFromTimestamp = await adminProxyClient.getTransfersFromOmnibusAccount(transfers[i].timestamp)
-        console.log(omnibusCreditsFromTimestamp.transfers.length, 'transfers occured since', Date(transfers[i].timestamp * 1000))
-        expect(omnibusCreditsFromTimestamp.transfers.length).to.be.equal(transfers.length - i)
+        const adminPrimaryCreditsSinceTimestamp = await adminProxyClient.getTransfersFromPrimaryAccount(transfers[i].timestamp)
+        console.log(adminPrimaryCreditsSinceTimestamp.transfers.length, 'transfers occured since', Date(transfers[i].timestamp * 1000))
+        expect(adminPrimaryCreditsSinceTimestamp.transfers.length).to.be.equal(transfers.length - i)
       }
     })
 
   })
 
-  describe('makeTransferToOmnibusAccount', () => {
-    let toOmnibusTimestamp, tx
+  describe('makeTransferToAdminPrimaryAccount', () => {
+    let toAdminPrimaryAccountTimestamp, tx
     const transferAmount = '5.43'
-    const message = 'test-to omnibus account'
-    let omnibusSummaryBefore
-    let omnibusSummaryAfter
+    const message = 'test-to adminPrimary account'
+    let adminPrimarySummaryBefore
+    let adminPrimarySummaryAfter
     let userSummaryBefore
     let userSummaryAfter
 
     before (async () => {
-      toOmnibusTimestamp = new Date() / 1000
-      omnibusSummaryBefore = await adminProxyClient.getAccountDetails()
+      toAdminPrimaryAccountTimestamp = new Date() / 1000
+      adminPrimarySummaryBefore = await adminProxyClient.getAccountDetails()
       userSummaryBefore = await user1ProxyClient.getAccountDetails()
 
       await sleep(500) // You need to sleep for a bit here because cyclos is slow...
-      tx = await user1ProxyClient.makeTransferToOmnibusAccount(transferAmount, message)
+      tx = await user1ProxyClient.makeTransferToAdminPrimaryAccount(transferAmount, message)
       await sleep(1000) // You need to sleep for a bit here because cyclos is slow...
     })
     it("should get the transfer that was created by timestamp and it should have the correct details", async () => {
-      const omnibusToTransfersFromTimestamp = await adminProxyClient.getTransfersToOmnibusAccount(toOmnibusTimestamp)
-      expect(omnibusToTransfersFromTimestamp.transfers.length).to.be.equal(1)
-      expect(omnibusToTransfersFromTimestamp.transfers[0].id).to.be.equal(tx.transferId)
-      expect(omnibusToTransfersFromTimestamp.transfers[0].amount).to.be.equal(transferAmount)
-      expect(omnibusToTransfersFromTimestamp.transfers[0].description).to.be.equal(message)
+      const adminPrimaryToTransfersSinceTimestamp = await adminProxyClient.getTransfersToPrimaryAccount(toAdminPrimaryAccountTimestamp)
+      expect(adminPrimaryToTransfersSinceTimestamp.transfers.length).to.be.equal(1)
+      expect(adminPrimaryToTransfersSinceTimestamp.transfers[0].id).to.be.equal(tx.transferId)
+      expect(adminPrimaryToTransfersSinceTimestamp.transfers[0].amount).to.be.equal(transferAmount)
+      expect(adminPrimaryToTransfersSinceTimestamp.transfers[0].description).to.be.equal(message)
     })
-    it("should reflect the correct amonut in the omnibus Account summary after transfers", async () => {
-      omnibusSummaryAfter = await adminProxyClient.getAccountDetails()
+    it("should reflect the correct amonut in the adminPrimary Account summary after transfers", async () => {
+      adminPrimarySummaryAfter = await adminProxyClient.getAccountDetails()
 
       expect(
-        omnibusSummaryAfter.status.balance
+        adminPrimarySummaryAfter.status.balance
       ).to.be.equal(
         // NOTE:: Beware of the rounding error!
-        (parseFloat(omnibusSummaryBefore.status.balance) + parseFloat(transferAmount)).toFixed(2)
+        (parseFloat(adminPrimarySummaryBefore.status.balance) + parseFloat(transferAmount)).toFixed(2)
       )
     })
     it("should reflect the correct amonut in the user account summary after transfers", async () => {
@@ -109,37 +109,37 @@ describe("The core banking system proxy", function() {
       )
     })
   })
-  describe('makeTransferFromOmnibusAccount', () => {
-    let fromOmnibusTimestamp, tx
+  describe('makeTransferFromAdminPrimaryAccount', () => {
+    let fromAdminPrimaryAccountTimestamp, tx
     const transferAmount = '3.11'
-    const message = 'test-from omnibus account'
-    let omnibusSummaryBefore
-    let omnibusSummaryAfter
+    const message = 'test-from adminPrimary account'
+    let adminPrimarySummaryBefore
+    let adminPrimarySummaryAfter
     let userSummaryBefore
     let userSummaryAfter
 
     before (async () => {
-      fromOmnibusTimestamp = new Date() / 1000
-      omnibusSummaryBefore = await adminProxyClient.getAccountDetails()
+      fromAdminPrimaryAccountTimestamp = new Date() / 1000
+      adminPrimarySummaryBefore = await adminProxyClient.getAccountDetails()
       userSummaryBefore = await user1ProxyClient.getAccountDetails()
-      tx = await adminProxyClient.makeTransferFromOmnibusAccount(transferAmount, message, config.cbsAccountUser1)
+      tx = await adminProxyClient.makeTransferFromAdminPrimaryAccount(transferAmount, message, config.cbsAccountUser1)
       await sleep(1000) // You need to sleep for a bit here because cyclos is slow...
     })
     it("should get the transfer that was created by timestamp and it should have the correct details", async () => {
-      const omnibusFromTransfersFromTimestamp = await adminProxyClient.getTransfersFromOmnibusAccount(fromOmnibusTimestamp)
-      expect(omnibusFromTransfersFromTimestamp.transfers.length).to.be.equal(1)
-      expect(omnibusFromTransfersFromTimestamp.transfers[0].id).to.be.equal(tx.transferId)
-      expect(omnibusFromTransfersFromTimestamp.transfers[0].amount).to.be.equal('-' + transferAmount)
-      expect(omnibusFromTransfersFromTimestamp.transfers[0].description).to.be.equal(message)
+      const adminPrimaryFromTransfersSinceTimestamp = await adminProxyClient.getTransfersFromPrimaryAccount(fromAdminPrimaryAccountTimestamp)
+      expect(adminPrimaryFromTransfersSinceTimestamp.transfers.length).to.be.equal(1)
+      expect(adminPrimaryFromTransfersSinceTimestamp.transfers[0].id).to.be.equal(tx.transferId)
+      expect(adminPrimaryFromTransfersSinceTimestamp.transfers[0].amount).to.be.equal('-' + transferAmount)
+      expect(adminPrimaryFromTransfersSinceTimestamp.transfers[0].description).to.be.equal(message)
     })
-    it("should reflect the correct amonut in the omnibus Account summary after transfers", async () => {
-      omnibusSummaryAfter = await adminProxyClient.getAccountDetails()
+    it("should reflect the correct amonut in the adminPrimary Account summary after transfers", async () => {
+      adminPrimarySummaryAfter = await adminProxyClient.getAccountDetails()
 
       expect(
-        omnibusSummaryAfter.status.balance
+        adminPrimarySummaryAfter.status.balance
       ).to.be.equal(
         // NOTE:: Beware of the rounding error!
-        (parseFloat(omnibusSummaryBefore.status.balance) - parseFloat(transferAmount)).toFixed(2)
+        (parseFloat(adminPrimarySummaryBefore.status.balance) - parseFloat(transferAmount)).toFixed(2)
       )
     })
     it("should reflect the correct amonut in the user account summary after transfers", async () => {

--- a/test/index.js
+++ b/test/index.js
@@ -29,17 +29,25 @@ describe("The core banking system proxy", function() {
       const sessionToken = await getSessionToken(config.cbsUnameUser1, config.cbsPasswordUser1, config.cbsProxyUrl)
       transfers = await makeRandomTransfersToOmnibusAccount(11, sessionToken)
     })
-    it("returns a list of TO transfers to the omnibus account after a certain date", async () => {
+    it("returns a list of TO transfers of the omnibus account after a certain date", async () => {
       for (let i = 0; i < transfers.length; ++i) {
         const omnibusCreditsFromTimestamp = await adminProxyClient.getTransfersToOmnibusAccount(transfers[i].timestamp)
         console.log(omnibusCreditsFromTimestamp.transfers.length, 'transfers occured since', Date(transfers[i].timestamp * 1000))
         expect(omnibusCreditsFromTimestamp.transfers.length).to.be.equal(transfers.length - i)
       }
     })
+    it("returns a list of FROM transfers of user account after a certain date", async () => {
+      for (let i = 0; i < transfers.length; ++i) {
+        const userDebitTrnsferFromTimestamp = await adminProxyClient.getTransfersToOmnibusAccount(transfers[i].timestamp)
+        console.log(userDebitTrnsferFromTimestamp.transfers.length, 'transfers occured since', Date(transfers[i].timestamp * 1000))
+        expect(userDebitTrnsferFromTimestamp.transfers.length).to.be.equal(transfers.length - i)
+      }
+    })
   })
 
   describe('getTransfersFromOmnibusAccount', () => {
     let transfers
+    let user
 
     before (async () => {
       const sessionToken = await getSessionToken(config.cbsUnameAdmin, config.cbsPasswordAdmin, config.cbsProxyUrl)
@@ -52,15 +60,23 @@ describe("The core banking system proxy", function() {
         expect(omnibusCreditsFromTimestamp.transfers.length).to.be.equal(transfers.length - i)
       }
     })
+
   })
 
   describe('makeTransferToOmnibusAccount', () => {
     let toOmnibusTimestamp, tx
     const transferAmount = '5.43'
     const message = 'test-to omnibus account'
+    let omnibusSummaryBefore
+    let omnibusSummaryAfter
+    let userSummaryBefore
+    let userSummaryAfter
 
     before (async () => {
       toOmnibusTimestamp = new Date() / 1000
+      omnibusSummaryBefore = await adminProxyClient.getAccountDetails()
+      userSummaryBefore = await user1ProxyClient.getAccountDetails()
+
       await sleep(500) // You need to sleep for a bit here because cyclos is slow...
       tx = await user1ProxyClient.makeTransferToOmnibusAccount(transferAmount, message)
       await sleep(1000) // You need to sleep for a bit here because cyclos is slow...
@@ -72,14 +88,40 @@ describe("The core banking system proxy", function() {
       expect(omnibusToTransfersFromTimestamp.transfers[0].amount).to.be.equal(transferAmount)
       expect(omnibusToTransfersFromTimestamp.transfers[0].description).to.be.equal(message)
     })
+    it("should reflect the correct amonut in the omnibus Account summary after transfers", async () => {
+      omnibusSummaryAfter = await adminProxyClient.getAccountDetails()
+
+      expect(
+        omnibusSummaryAfter.status.balance
+      ).to.be.equal(
+        // NOTE:: Beware of the rounding error!
+        (parseFloat(omnibusSummaryBefore.status.balance) + parseFloat(transferAmount)).toFixed(2)
+      )
+    })
+    it("should reflect the correct amonut in the user account summary after transfers", async () => {
+      userAccountSummaryAfter = await user1ProxyClient.getAccountDetails()
+
+      expect(
+        userAccountSummaryAfter.status.balance
+      ).to.be.equal(
+        // NOTE:: Beware of the rounding error!
+        (parseFloat(userSummaryBefore.status.balance) - parseFloat(transferAmount)).toFixed(2)
+      )
+    })
   })
   describe('makeTransferFromOmnibusAccount', () => {
     let fromOmnibusTimestamp, tx
     const transferAmount = '3.11'
     const message = 'test-from omnibus account'
+    let omnibusSummaryBefore
+    let omnibusSummaryAfter
+    let userSummaryBefore
+    let userSummaryAfter
 
     before (async () => {
       fromOmnibusTimestamp = new Date() / 1000
+      omnibusSummaryBefore = await adminProxyClient.getAccountDetails()
+      userSummaryBefore = await user1ProxyClient.getAccountDetails()
       tx = await adminProxyClient.makeTransferFromOmnibusAccount(transferAmount, message, config.cbsAccountUser1)
       await sleep(1000) // You need to sleep for a bit here because cyclos is slow...
     })
@@ -89,6 +131,26 @@ describe("The core banking system proxy", function() {
       expect(omnibusFromTransfersFromTimestamp.transfers[0].id).to.be.equal(tx.transferId)
       expect(omnibusFromTransfersFromTimestamp.transfers[0].amount).to.be.equal('-' + transferAmount)
       expect(omnibusFromTransfersFromTimestamp.transfers[0].description).to.be.equal(message)
+    })
+    it("should reflect the correct amonut in the omnibus Account summary after transfers", async () => {
+      omnibusSummaryAfter = await adminProxyClient.getAccountDetails()
+
+      expect(
+        omnibusSummaryAfter.status.balance
+      ).to.be.equal(
+        // NOTE:: Beware of the rounding error!
+        (parseFloat(omnibusSummaryBefore.status.balance) - parseFloat(transferAmount)).toFixed(2)
+      )
+    })
+    it("should reflect the correct amonut in the user account summary after transfers", async () => {
+      userAccountSummaryAfter = await user1ProxyClient.getAccountDetails()
+
+      expect(
+        userAccountSummaryAfter.status.balance
+      ).to.be.equal(
+        // NOTE:: Beware of the rounding error!
+        (parseFloat(userSummaryBefore.status.balance) + parseFloat(transferAmount)).toFixed(2)
+      )
     })
   })
 })

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,36 @@
+var webpack = require('webpack');
+var path = require('path');
+var libraryName = 'library';
+var outputFile = libraryName + '.js';
+
+var config = {
+  entry: __dirname + '/src/index.js',
+  devtool: 'source-map',
+  output: {
+    path: __dirname + '/lib',
+    filename: outputFile,
+    library: libraryName,
+    libraryTarget: 'umd',
+    umdNamedDefine: true
+  },
+  module: {
+    loaders: [
+      {
+        test: /(\.jsx|\.js)$/,
+        loader: 'babel',
+        exclude: /(node_modules|bower_components)/
+      },
+      {
+        test: /(\.jsx|\.js)$/,
+        loader: "eslint-loader",
+        exclude: /node_modules/
+      }
+    ]
+  },
+  resolve: {
+    root: path.resolve('./src'),
+    extensions: ['', '.js']
+  }
+};
+
+module.exports = config;


### PR DESCRIPTION
This includes the changes for the #22 pr for the cbs-proxy and will only work when running against that version.

Also this has not been published to NPM - we must publish it as soon as the PR is done.

To test:

1. Start cyclos on localhost 4000 (use tag `TAG=cash_tokenizer_ci_1 docker-compose up -d`)
2. run `npm start` for the cbs-proxy (must be latest version)
3. run `npm test` (in the cbs-proxy-client folder).


Also - 
Run `circleci build` ( or `docker stop $(docker ps -a -q); docker rm $(docker ps -a -q); docker network rm cyclos-cbs-proxy-client-test; circleci build` to make sure you have a clean setup) 