### PR TITLE
closes #15 - get primary account Id from the CbsProxyClient object

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -108,6 +108,8 @@ const createTokenProxy = async (username, password, url) => {
     return transferResult
   }
 
+  const getPrimaryAccountId = () => primaryAccountId
+
   return {
     getTransfersToPrimaryAccount,
     getTransfersFromPrimaryAccount,
@@ -117,7 +119,8 @@ const createTokenProxy = async (username, password, url) => {
     getTransfersFromOmnibusAccount: getTransfersFromPrimaryAccount,
     makeTransferToOmnibusAccount: makeTransferToAdminPrimaryAccount,
     makeTransferFromOmnibusAccount: makeTransferFromAdminPrimaryAccount,
-    getAccountDetails
+    getAccountDetails,
+    getPrimaryAccountId,
   }
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -46,7 +46,7 @@ const getAccountDetailsOption = (queryParameters) => ({
 })
 
 // NOTE: I chose to use a functor like constructor with closures rather than classes because I don't like needing to call `new`
-const createTokenProxy = async (username, password, url) => {
+const createCbsProxy = async (username, password, url) => {
   const sessionToken = (
     await fetchJson(
       getAuthUri(url),
@@ -124,4 +124,4 @@ const createTokenProxy = async (username, password, url) => {
   }
 }
 
-module.exports = createTokenProxy
+module.exports = createCbsProxy

--- a/test/index.js
+++ b/test/index.js
@@ -60,7 +60,6 @@ describe("The core banking system proxy", function() {
         expect(adminPrimaryCreditsSinceTimestamp.transfers.length).to.be.equal(transfers.length - i)
       }
     })
-
   })
 
   describe('makeTransferToAdminPrimaryAccount', () => {
@@ -106,6 +105,16 @@ describe("The core banking system proxy", function() {
       ).to.be.equal(
         // NOTE:: Beware of the rounding error!
         (parseFloat(userSummaryBefore.status.balance) - parseFloat(transferAmount)).toFixed(2)
+      )
+    })
+    it("should return the same `primaryAccountId` as the `getPrimaryAccountId` function", async () => {
+      userAccountSummary = await user1ProxyClient.getAccountDetails()
+      const primaryAccountId = user1ProxyClient.getPrimaryAccountId()
+
+      expect(
+        userAccountSummary.id
+      ).to.be.equal(
+        primaryAccountId
       )
     })
   })


### PR DESCRIPTION
Note, this includes the fixing the name of the default object that the library returns. This of course doesn't affect anything since it is the `module.export`.